### PR TITLE
fix: correct module name to Creative Intelligence Suite

### DIFF
--- a/src/module.yaml
+++ b/src/module.yaml
@@ -1,6 +1,6 @@
 code: cis
-name: "CIS: Creative Innovation Suite"
-header: "BMad Creative Innovation Suite (CIS) Module"
+name: "CIS: Creative Intelligence Suite"
+header: "BMad Creative Intelligence Suite (CIS) Module"
 subheader: "Unleash your creativity with the BMad CIS!"
 description: ""
 default_selected: false # This module will not be selected by default for new installations


### PR DESCRIPTION
## Summary
- The `name` and `header` fields in `src/module.yaml` incorrectly used "Creative Innovation Suite" instead of "Creative Intelligence Suite"
- The README and npm package name both use "Intelligence", so the module.yaml was inconsistent

## Changes
- `src/module.yaml`: `name` field updated from "Creative Innovation Suite" to "Creative Intelligence Suite"
- `src/module.yaml`: `header` field updated from "BMad Creative Innovation Suite (CIS) Module" to "BMad Creative Intelligence Suite (CIS) Module"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CIS module branding terminology from "Creative Innovation Suite" to "Creative Intelligence Suite" in module metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->