### PR TITLE
docs: add BMad Ecosystem cross-links to sidebar

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -104,6 +104,20 @@ export default defineConfig({
           collapsed: true,
           autogenerate: { directory: 'reference' },
         },
+        {
+          label: 'BMad Ecosystem',
+          collapsed: false,
+          items: [
+            { label: 'BMad Method', link: 'https://docs.bmad-method.org/', attrs: { target: '_blank' } },
+            { label: 'BMad Builder', link: 'https://bmad-builder-docs.bmad-method.org/', attrs: { target: '_blank' } },
+            { label: 'Game Dev Studio', link: 'https://game-dev-studio-docs.bmad-method.org/', attrs: { target: '_blank' } },
+            {
+              label: 'Test Architect (TEA)',
+              link: 'https://bmad-code-org.github.io/bmad-method-test-architecture-enterprise/',
+              attrs: { target: '_blank' },
+            },
+          ],
+        },
       ],
 
       // Credits in footer


### PR DESCRIPTION
## Summary
- Adds a "BMad Ecosystem" sidebar group linking to BMad Method, BMad Builder, Game Dev Studio, and TEA docs sites
- Links open in new tabs

## Test plan
- [x] Sidebar config follows same pattern verified on BMad Method dev server