### PR TITLE
docs: add BMad Builder announcement banner

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -41,6 +41,10 @@ export default defineConfig({
       title: 'Creative Intelligence Suite',
       tagline: 'Innovation, brainstorming, and problem-solving agents for the BMad Method.',
 
+      banner: {
+        content: 'Build your own BMad modules and share them with the community! <a href="https://bmad-builder-docs.bmad-method.org/tutorials/build-your-first-module/">Get started</a> or <a href="https://bmad-builder-docs.bmad-method.org/how-to/distribute-your-module/">submit to the marketplace</a>.',
+      },
+
       favicon: '/favicon.ico',
 
       // Social links


### PR DESCRIPTION
## Summary

- Adds Starlight announcement banner to the docs site promoting BMad Builder module creation and marketplace submission
- Links to the Build Your First Module tutorial and Distribute Your Module how-to on the BMB docs site

## Test plan

- [ ] Verify docs site builds and banner renders correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a website banner providing convenient access to important resources. The banner includes links to help users get started with the platform and to submit contributions to the marketplace, improving discoverability of these key tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->