### PR TITLE
feat: add _meta row for bmad-help llms.txt integration

### DIFF
--- a/src/module-help.csv
+++ b/src/module-help.csv
@@ -1,4 +1,5 @@
 module,skill,display-name,menu-code,description,action,args,phase,after,before,required,output-location,outputs
+Creative Intelligence Suite,_meta,,,,,,,,,false,https://cis-docs.bmad-method.org/llms.txt,
 Creative Intelligence Suite,bmad-cis-innovation-strategy,Innovation Strategy,IS,Identify disruption opportunities and architect business model innovation.,,anytime,,,false,output_folder,innovation strategy
 Creative Intelligence Suite,bmad-cis-problem-solving,Problem Solving,PS,Apply systematic problem-solving methodologies to crack complex challenges.,,anytime,,,false,output_folder,problem solution
 Creative Intelligence Suite,bmad-cis-design-thinking,Design Thinking,DT,Guide human-centered design processes using empathy-driven methodologies.,,anytime,,,false,output_folder,design thinking


### PR DESCRIPTION
## Summary
- Adds `_meta` row to `src/module-help.csv` registering `https://cis-docs.bmad-method.org/llms.txt`
- Enables bmad-help to fetch CIS docs when users ask general questions about the module

## Test plan
- [x] llms.txt URL returns HTTP 200
- [ ] Verify _meta row appears in merged bmad-help.csv after install