### PR TITLE
fix(catalog): normalize module-help.csv to documented 13-column schema

### DIFF
--- a/src/module-help.csv
+++ b/src/module-help.csv
@@ -1,7 +1,7 @@
 module,skill,display-name,menu-code,description,action,args,phase,after,before,required,output-location,outputs
 Creative Intelligence Suite,_meta,,,,,,,,,false,https://cis-docs.bmad-method.org/llms.txt,
-Creative Intelligence Suite,bmad-cis-innovation-strategy,Innovation Strategy,IS,Identify disruption opportunities and architect business model innovation.,,anytime,,,false,output_folder,innovation strategy
-Creative Intelligence Suite,bmad-cis-problem-solving,Problem Solving,PS,Apply systematic problem-solving methodologies to crack complex challenges.,,anytime,,,false,output_folder,problem solution
-Creative Intelligence Suite,bmad-cis-design-thinking,Design Thinking,DT,Guide human-centered design processes using empathy-driven methodologies.,,anytime,,,false,output_folder,design thinking
-Creative Intelligence Suite,bmad-brainstorming,Brainstorming,BS,Facilitate brainstorming sessions using one or more techniques.,,anytime,,,false,output_folder,brainstorming session results
-Creative Intelligence Suite,bmad-cis-storytelling,Storytelling,ST,Craft compelling narratives using proven story frameworks and techniques.,,anytime,,,false,output_folder,narrative/story
+Creative Intelligence Suite,bmad-cis-innovation-strategy,Innovation Strategy,IS,Identify disruption opportunities and architect business model innovation.,,,anytime,,,false,output_folder,innovation strategy
+Creative Intelligence Suite,bmad-cis-problem-solving,Problem Solving,PS,Apply systematic problem-solving methodologies to crack complex challenges.,,,anytime,,,false,output_folder,problem solution
+Creative Intelligence Suite,bmad-cis-design-thinking,Design Thinking,DT,Guide human-centered design processes using empathy-driven methodologies.,,,anytime,,,false,output_folder,design thinking
+Creative Intelligence Suite,bmad-brainstorming,Brainstorming,BS,Facilitate brainstorming sessions using one or more techniques.,,,anytime,,,false,output_folder,brainstorming session results
+Creative Intelligence Suite,bmad-cis-storytelling,Storytelling,ST,Craft compelling narratives using proven story frameworks and techniques.,,,anytime,,,false,output_folder,narrative/story


### PR DESCRIPTION
## Summary

- Five rows in \`src/module-help.csv\` were missing one column between \`description\` and \`phase\`, leaving them at 12 fields instead of 13.

## Why

CSV consumers that read by header position were silently mapping data into the wrong columns (\`phase\` value into \`args\`, \`required\` into \`before\`, etc). Inserting one empty cell at index 5 restores correct alignment with the documented header (\`module,skill,display-name,menu-code,description,action,args,phase,after,before,required,output-location,outputs\`).

This is part of a coordinated cleanup also fixing the installer in BMAD-METHOD (PR #2349 there) and the same defect across bmad-method-test-architecture-enterprise, bmad-method-wds-expansion, bmad-module-game-dev-studio.

## Test plan

- [x] All rows re-audited with csv-parse — every data row now has exactly 13 fields
- [ ] Run a fresh install and confirm \`_bmad/_config/bmad-help.csv\` data lands in the right columns