### PR TITLE
fix(catalog): rename module-help.csv after/before columns to preceded-by/followed-by

### DIFF
--- a/src/module-help.csv
+++ b/src/module-help.csv
@@ -1,4 +1,4 @@
-module,skill,display-name,menu-code,description,action,args,phase,after,before,required,output-location,outputs
+module,skill,display-name,menu-code,description,action,args,phase,preceded-by,followed-by,required,output-location,outputs
 Creative Intelligence Suite,_meta,,,,,,,,,false,https://cis-docs.bmad-method.org/llms.txt,
 Creative Intelligence Suite,bmad-cis-innovation-strategy,Innovation Strategy,IS,Identify disruption opportunities and architect business model innovation.,,,anytime,,,false,output_folder,innovation strategy
 Creative Intelligence Suite,bmad-cis-problem-solving,Problem Solving,PS,Apply systematic problem-solving methodologies to crack complex challenges.,,,anytime,,,false,output_folder,problem solution


### PR DESCRIPTION
## Summary

- Renamed `after`/`before` columns to `preceded-by`/`followed-by` in `src/module-help.csv`.
- Aligns with the canonical 13-column schema introduced in BMAD-METHOD v6.6.0.
- Warning-only fix: data was already loaded positionally, so no behavior change.

Note: the previous "normalize module-help.csv to documented 13-column schema (#32)" commit on main appears to have addressed a different aspect of the schema, not the column-name rename.

## Test plan

- [ ] Install cis and confirm no "header does not match canonical schema" warning during manifest generation.