### PR TITLE
docs(changelog): add v0.2.1 entry for module-help.csv header rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v0.2.1 - 2026-05-17 — module-help.csv column alignment
+
+* Renamed `after`/`before` columns in `src/module-help.csv` to `preceded-by`/`followed-by` to match the canonical 13-column schema introduced in BMAD-METHOD v6.6.0. Warning-only fix; data was already loaded positionally (#35).
+
 ## v0.2.0 - Apr 21, 2026 — customize.toml pattern across agents and workflows
 
 ### Agent customization surface


### PR DESCRIPTION
## Summary

- Adds the v0.2.1 changelog entry that the release workflow needs to publish.
- Documents the `after`/`before` → `preceded-by`/`followed-by` rename from #35.

## Test plan

- [ ] Merge this PR.
- [ ] Re-trigger the Release workflow to bump v0.2.0 → v0.2.1, push the tag, and create the GitHub Release.