### PR TITLE
fix: invoke the customization resolver with uv run

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Version](https://img.shields.io/npm/v/bmad-creative-intelligence-suite?color=blue&label=version)](https://www.npmjs.com/package/bmad-creative-intelligence-suite)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Python Version](https://img.shields.io/badge/python-%3E%3D3.10-blue?logo=python&logoColor=white)](https://www.python.org)
+[![Python Version](https://img.shields.io/badge/python-%3E%3D3.11-blue?logo=python&logoColor=white)](https://www.python.org)
 [![uv](https://img.shields.io/badge/uv-package%20manager-blueviolet?logo=uv)](https://docs.astral.sh/uv/)
 [![Discord](https://img.shields.io/badge/Discord-Join%20Community-7289da?logo=discord&logoColor=white)](https://discord.gg/gk8jAdXWmj)
 

--- a/src/skills/bmad-cis-agent-brainstorming-coach/SKILL.md
+++ b/src/skills/bmad-cis-agent-brainstorming-coach/SKILL.md
@@ -20,7 +20,7 @@ You are Carson, the Elite Brainstorming Specialist. You facilitate breakthrough 
 
 ### Step 1: Resolve the Agent Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key agent`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key agent`
 
 **If the script fails**, resolve the `agent` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/skills/bmad-cis-agent-creative-problem-solver/SKILL.md
+++ b/src/skills/bmad-cis-agent-creative-problem-solver/SKILL.md
@@ -20,7 +20,7 @@ You are Dr. Quinn, the Master Problem Solver. You crack complex challenges with 
 
 ### Step 1: Resolve the Agent Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key agent`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key agent`
 
 **If the script fails**, resolve the `agent` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/skills/bmad-cis-agent-design-thinking-coach/SKILL.md
+++ b/src/skills/bmad-cis-agent-design-thinking-coach/SKILL.md
@@ -20,7 +20,7 @@ You are Maya, the Design Thinking Maestro. You guide human-centered design proce
 
 ### Step 1: Resolve the Agent Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key agent`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key agent`
 
 **If the script fails**, resolve the `agent` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/skills/bmad-cis-agent-innovation-strategist/SKILL.md
+++ b/src/skills/bmad-cis-agent-innovation-strategist/SKILL.md
@@ -20,7 +20,7 @@ You are Victor, the Disruptive Innovation Oracle. You identify disruption opport
 
 ### Step 1: Resolve the Agent Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key agent`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key agent`
 
 **If the script fails**, resolve the `agent` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/skills/bmad-cis-agent-presentation-master/SKILL.md
+++ b/src/skills/bmad-cis-agent-presentation-master/SKILL.md
@@ -20,7 +20,7 @@ You are Caravaggio, the Visual Communication and Presentation Expert. You design
 
 ### Step 1: Resolve the Agent Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key agent`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key agent`
 
 **If the script fails**, resolve the `agent` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/skills/bmad-cis-agent-storyteller/SKILL.md
+++ b/src/skills/bmad-cis-agent-storyteller/SKILL.md
@@ -20,7 +20,7 @@ You are Sophia, the Master Storyteller. You craft compelling narratives using pr
 
 ### Step 1: Resolve the Agent Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key agent`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key agent`
 
 **If the script fails**, resolve the `agent` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/skills/bmad-cis-design-thinking/SKILL.md
+++ b/src/skills/bmad-cis-design-thinking/SKILL.md
@@ -20,7 +20,7 @@ description: 'Guide human-centered design processes using empathy-driven methodo
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 
@@ -268,7 +268,7 @@ Determine the next cycle:
 <template-output>action_items</template-output>
 <template-output>success_metrics</template-output>
 
-<action>Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
+<action>Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
 </step>
 
 </workflow>

--- a/src/skills/bmad-cis-innovation-strategy/SKILL.md
+++ b/src/skills/bmad-cis-innovation-strategy/SKILL.md
@@ -20,7 +20,7 @@ description: 'Identify disruption opportunities and architect business model inn
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 
@@ -341,7 +341,7 @@ Identify and mitigate key risks:
 <template-output>key_risks</template-output>
 <template-output>risk_mitigation</template-output>
 
-<action>Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
+<action>Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
 </step>
 
 </workflow>

--- a/src/skills/bmad-cis-problem-solving/SKILL.md
+++ b/src/skills/bmad-cis-problem-solving/SKILL.md
@@ -20,7 +20,7 @@ description: 'Apply systematic problem-solving methodologies to complex challeng
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 
@@ -301,7 +301,7 @@ Identify risks and mitigation:
 <template-output>risk_mitigation</template-output>
 <template-output>adjustment_triggers</template-output>
 
-<action>If the user will NOT run the optional Step 9 reflection, run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
+<action>If the user will NOT run the optional Step 9 reflection, run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
 </step>
 
 <step n="9" goal="Capture lessons learned" optional="true">
@@ -319,7 +319,7 @@ Facilitate reflection:
 <template-output>what_worked</template-output>
 <template-output>what_to_avoid</template-output>
 
-<action>Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
+<action>Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
 </step>
 
 </workflow>

--- a/src/skills/bmad-cis-storytelling/SKILL.md
+++ b/src/skills/bmad-cis-storytelling/SKILL.md
@@ -20,7 +20,7 @@ description: 'Craft compelling narratives using story frameworks. Use when the u
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 
@@ -347,7 +347,7 @@ Confirm completion with: "Story complete, {user_name}! Your narrative has been s
 
 <template-output>agent_role, agent_name, user_name, date</template-output>
 
-<action>Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
+<action>Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
 </step>
 
 </workflow>


### PR DESCRIPTION
Every skill and agent shelled out to a bare `python3` to run `_bmad/scripts/resolve_customization.py`.

That script declares `requires-python = ">=3.11"` and hard-exits below it, because `tomllib` is a 3.11 stdlib addition. On macOS without Homebrew or Ubuntu 22.04 — where `python3` is 3.10 — activation fell through to the skill's "if the script fails" path and hand-merged the TOML layers in-context. No error surfaced to the user.

`uv run` reads the script's own `requires-python` and provisions a matching interpreter, so whatever `python3` resolves to on PATH no longer matters.

## Changes

- **15 invocations** across 10 files: 6 agents (`--key agent`) and 4 workflows (`--key workflow` and `--key workflow.on_complete`)
- **README badge** corrected from `>=3.10` to `>=3.11` — it advertised a floor that cannot run the module

Only the leading `python3` token changes; every argument is untouched.

## Verification

`npm test` passes (lint, markdownlint, prettier). No bare `python3 <script>.py` remains anywhere in the repo.

Part of an ecosystem-wide pass — the same fix is going into bmad-method, bmad-builder, game-dev-studio, and test-architecture-enterprise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documented minimum Python version to 3.11 or newer.

* **Bug Fixes**
  * Improved workflow and agent customization resolution across supported skills by using the project’s managed execution environment.
  * Applied the updated execution method consistently during workflow activation and completion handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->