### PR TITLE
docs(changelog): backfill v0.2.1 entry for module-help.csv schema work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
 
 - **`uv` is what you need; a system Python is not.** CIS skills no longer invoke a bare interpreter anywhere. Install [`uv`](https://docs.astral.sh/uv/) and it provisions the right Python per script.
 
+## v0.2.1 - May 17, 2026 — module-help.csv column alignment
+
+- Normalized `src/module-help.csv` to the documented 13-column schema (#32).
+- Renamed `after`/`before` columns in `src/module-help.csv` to `preceded-by`/`followed-by` to match the canonical 13-column schema introduced in BMAD-METHOD v6.6.0. Warning-only fix; data was already loaded positionally (#35).
+
 ## v0.2.0 - Apr 21, 2026 — customize.toml pattern across agents and workflows
 
 ### Agent customization surface


### PR DESCRIPTION
The v0.2.1 tag exists but CHANGELOG.md skips from v0.3.0 straight to v0.2.0, leaving the tagged content (#32 13-column normalization, #35 preceded-by/followed-by rename) undocumented. The release workflow extracts notes by matching the version heading and hard-fails when the section is missing, so the gap would break a future patch release. Supersedes #36, which is conflicted after #38 rewrote the same region.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 0.2.1.
  * Documented updates to module help data formatting and terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->