### PR TITLE
chore: default persistent_facts to an empty array

### DIFF
--- a/src/skills/bmad-cis-agent-brainstorming-coach/customize.toml
+++ b/src/skills/bmad-cis-agent-brainstorming-coach/customize.toml
@@ -18,9 +18,7 @@ icon = "🧠"
 activation_steps_prepend = []
 activation_steps_append = []
 
-persistent_facts = [
-  "file:{project-root}/**/project-context.md",
-]
+persistent_facts = []
 
 role = "Facilitate breakthrough ideation using creative techniques and systematic innovation methods so wild ideas get airtime and the best ones rise."
 identity = "Twenty years leading breakthrough sessions — channels Alex Osborn's brainstorming foundations and Keith Johnstone's improv-born yes-and instinct, fluent in group dynamics, creative techniques, and the art of making it safe to say the ridiculous thing."

--- a/src/skills/bmad-cis-agent-creative-problem-solver/customize.toml
+++ b/src/skills/bmad-cis-agent-creative-problem-solver/customize.toml
@@ -18,9 +18,7 @@ icon = "🔬"
 activation_steps_prepend = []
 activation_steps_append = []
 
-persistent_facts = [
-  "file:{project-root}/**/project-context.md",
-]
+persistent_facts = []
 
 role = "Crack complex challenges with systematic problem-solving methodologies — TRIZ, Theory of Constraints, Systems Thinking — so root causes come out in the open."
 identity = "Former aerospace engineer turned puzzle master — channels Genrich Altshuller's TRIZ discipline and Donella Meadows's systems-thinking clarity, with the steady reasoning of a diagnostician who has seen a thousand symptoms and is still hungry for the next one."

--- a/src/skills/bmad-cis-agent-design-thinking-coach/customize.toml
+++ b/src/skills/bmad-cis-agent-design-thinking-coach/customize.toml
@@ -18,9 +18,7 @@ icon = "🎨"
 activation_steps_prepend = []
 activation_steps_append = []
 
-persistent_facts = [
-  "file:{project-root}/**/project-context.md",
-]
+persistent_facts = []
 
 role = "Guide human-centered design processes using empathy-driven methodologies to turn real user needs into validated solutions."
 identity = "Fifteen years across Fortune 500s and startups — channels Tim Brown's IDEO empathy-first playbook and Don Norman's human-centered rigor, fluent in empathy mapping, rapid prototyping, and the craft of turning observation into insight."

--- a/src/skills/bmad-cis-agent-innovation-strategist/customize.toml
+++ b/src/skills/bmad-cis-agent-innovation-strategist/customize.toml
@@ -18,9 +18,7 @@ icon = "⚡"
 activation_steps_prepend = []
 activation_steps_append = []
 
-persistent_facts = [
-  "file:{project-root}/**/project-context.md",
-]
+persistent_facts = []
 
 role = "Identify disruption opportunities and architect business model innovation so strategic pivots land where the real value is."
 identity = "Former McKinsey strategist behind billion-dollar pivots — channels Clayton Christensen's disruption theory and Kim & Mauborgne's Blue Ocean reframing, fluent in Jobs-to-be-Done and the craft of making the winning move look obvious in hindsight."

--- a/src/skills/bmad-cis-agent-presentation-master/customize.toml
+++ b/src/skills/bmad-cis-agent-presentation-master/customize.toml
@@ -18,9 +18,7 @@ icon = "🎬"
 activation_steps_prepend = []
 activation_steps_append = []
 
-persistent_facts = [
-  "file:{project-root}/**/project-context.md",
-]
+persistent_facts = []
 
 role = "Design compelling presentations and visual communications across pitch decks, YouTube explainers, conference talks, and visual storytelling of every kind."
 identity = "Has dissected thousands of successful presentations — from viral explainers to funded pitch decks to TED talks — channels Nancy Duarte's presentation architecture and Saul Bass's cinematic graphic instinct, fluent in visual hierarchy, audience psychology, and the Excalidraw frame-as-scene discipline."

--- a/src/skills/bmad-cis-agent-storyteller/customize.toml
+++ b/src/skills/bmad-cis-agent-storyteller/customize.toml
@@ -35,9 +35,7 @@ activation_steps_append = []
 #   - a file reference prefixed with `file:`, e.g. "file:{project-root}/docs/standards.md"
 #     (glob patterns are supported; the file's contents are loaded and treated as facts).
 
-persistent_facts = [
-  "file:{project-root}/**/project-context.md",
-]
+persistent_facts = []
 
 role = "Craft compelling narratives using proven story frameworks so ideas land, move audiences, and persuade."
 identity = "Fifty years across journalism, screenwriting, and brand narrative — channels Robert McKee's structural rigor and Joseph Campbell's mythic-arc discipline, fluent in emotional psychology and the mechanics of audience engagement."

--- a/src/skills/bmad-cis-design-thinking/customize.toml
+++ b/src/skills/bmad-cis-design-thinking/customize.toml
@@ -30,9 +30,7 @@ activation_steps_append = []
 #   - a file reference prefixed with `file:`, e.g. "file:{project-root}/docs/standards.md"
 #     (glob patterns are supported; the file's contents are loaded and treated as facts).
 
-persistent_facts = [
-  "file:{project-root}/**/project-context.md",
-]
+persistent_facts = []
 
 # Scalar: executed when the workflow reaches Step 7 (Plan next iteration),
 # after refinements, action items, and success metrics are captured. Override wins.

--- a/src/skills/bmad-cis-innovation-strategy/customize.toml
+++ b/src/skills/bmad-cis-innovation-strategy/customize.toml
@@ -30,9 +30,7 @@ activation_steps_append = []
 #   - a file reference prefixed with `file:`, e.g. "file:{project-root}/docs/standards.md"
 #     (glob patterns are supported; the file's contents are loaded and treated as facts).
 
-persistent_facts = [
-  "file:{project-root}/**/project-context.md",
-]
+persistent_facts = []
 
 # Scalar: executed when the workflow reaches Step 9 (Define metrics and risk mitigation),
 # after the strategy document is finalized with leading/lagging indicators, decision gates,

--- a/src/skills/bmad-cis-problem-solving/customize.toml
+++ b/src/skills/bmad-cis-problem-solving/customize.toml
@@ -30,9 +30,7 @@ activation_steps_append = []
 #   - a file reference prefixed with `file:`, e.g. "file:{project-root}/docs/standards.md"
 #     (glob patterns are supported; the file's contents are loaded and treated as facts).
 
-persistent_facts = [
-  "file:{project-root}/**/project-context.md",
-]
+persistent_facts = []
 
 # Scalar: executed when the workflow reaches its final step — Step 9 (Capture lessons
 # learned) if the user runs the optional reflection, otherwise Step 8 (Define success

--- a/src/skills/bmad-cis-storytelling/customize.toml
+++ b/src/skills/bmad-cis-storytelling/customize.toml
@@ -30,9 +30,7 @@ activation_steps_append = []
 #   - a file reference prefixed with `file:`, e.g. "file:{project-root}/docs/standards.md"
 #     (glob patterns are supported; the file's contents are loaded and treated as facts).
 
-persistent_facts = [
-  "file:{project-root}/**/project-context.md",
-]
+persistent_facts = []
 
 # Scalar: executed when the workflow reaches Step 10 (Generate final output),
 # after the compiled story document is written to the output file. Override wins.


### PR DESCRIPTION
## What

Sets `persistent_facts = []` in every shipped `customize.toml`.

## Why

These files shipped pre-seeded with `"file:{project-root}/**/project-context.md"`, which made loading project-context an opt-out default baked into every skill rather than a customization the user chooses. `persistent_facts` is a user-customization surface; it should start empty.

## Notes

- Comments, spacing, and every other key are untouched — only the array value changes.
- Files that already had `persistent_facts = []` were left alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * Disabled automatic loading of project-context files across creative, design, problem-solving, innovation, presentation, and storytelling tools.
  * Persistent facts now start empty, allowing context to be added explicitly when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->