### PR TITLE
chore: sync marketplace plugin version to 0.3.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "bmad-creative-intelligence-suite",
       "source": "./",
       "description": "A suite of creative AI agents and workflows for brainstorming, problem-solving, design thinking, innovation strategy, storytelling, and presentations. Part of the BMad Method ecosystem.",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "author": {
         "name": "Brian (BMad) Madison"
       },


### PR DESCRIPTION
The release workflow bumps `package.json` but does not touch `.claude-plugin/marketplace.json`, so its versions drift unless bumped by hand. Bumping ahead of the 0.3.1 patch release.