### PR TITLE
fix(skills): pass --project-root to the customization resolver

### DIFF
--- a/src/skills/bmad-cis-agent-brainstorming-coach/SKILL.md
+++ b/src/skills/bmad-cis-agent-brainstorming-coach/SKILL.md
@@ -20,7 +20,7 @@ You are Carson, the Elite Brainstorming Specialist. You facilitate breakthrough 
 
 ### Step 1: Resolve the Agent Block
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key agent`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key agent`
 
 **If the script fails**, resolve the `agent` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/skills/bmad-cis-agent-creative-problem-solver/SKILL.md
+++ b/src/skills/bmad-cis-agent-creative-problem-solver/SKILL.md
@@ -20,7 +20,7 @@ You are Dr. Quinn, the Master Problem Solver. You crack complex challenges with 
 
 ### Step 1: Resolve the Agent Block
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key agent`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key agent`
 
 **If the script fails**, resolve the `agent` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/skills/bmad-cis-agent-design-thinking-coach/SKILL.md
+++ b/src/skills/bmad-cis-agent-design-thinking-coach/SKILL.md
@@ -20,7 +20,7 @@ You are Maya, the Design Thinking Maestro. You guide human-centered design proce
 
 ### Step 1: Resolve the Agent Block
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key agent`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key agent`
 
 **If the script fails**, resolve the `agent` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/skills/bmad-cis-agent-innovation-strategist/SKILL.md
+++ b/src/skills/bmad-cis-agent-innovation-strategist/SKILL.md
@@ -20,7 +20,7 @@ You are Victor, the Disruptive Innovation Oracle. You identify disruption opport
 
 ### Step 1: Resolve the Agent Block
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key agent`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key agent`
 
 **If the script fails**, resolve the `agent` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/skills/bmad-cis-agent-presentation-master/SKILL.md
+++ b/src/skills/bmad-cis-agent-presentation-master/SKILL.md
@@ -20,7 +20,7 @@ You are Caravaggio, the Visual Communication and Presentation Expert. You design
 
 ### Step 1: Resolve the Agent Block
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key agent`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key agent`
 
 **If the script fails**, resolve the `agent` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/skills/bmad-cis-agent-storyteller/SKILL.md
+++ b/src/skills/bmad-cis-agent-storyteller/SKILL.md
@@ -20,7 +20,7 @@ You are Sophia, the Master Storyteller. You craft compelling narratives using pr
 
 ### Step 1: Resolve the Agent Block
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key agent`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key agent`
 
 **If the script fails**, resolve the `agent` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/skills/bmad-cis-design-thinking/SKILL.md
+++ b/src/skills/bmad-cis-design-thinking/SKILL.md
@@ -20,7 +20,7 @@ description: 'Guide human-centered design processes using empathy-driven methodo
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 
@@ -268,7 +268,7 @@ Determine the next cycle:
 <template-output>action_items</template-output>
 <template-output>success_metrics</template-output>
 
-<action>Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
+<action>Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
 </step>
 
 </workflow>

--- a/src/skills/bmad-cis-innovation-strategy/SKILL.md
+++ b/src/skills/bmad-cis-innovation-strategy/SKILL.md
@@ -20,7 +20,7 @@ description: 'Identify disruption opportunities and architect business model inn
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 
@@ -341,7 +341,7 @@ Identify and mitigate key risks:
 <template-output>key_risks</template-output>
 <template-output>risk_mitigation</template-output>
 
-<action>Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
+<action>Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
 </step>
 
 </workflow>

--- a/src/skills/bmad-cis-problem-solving/SKILL.md
+++ b/src/skills/bmad-cis-problem-solving/SKILL.md
@@ -20,7 +20,7 @@ description: 'Apply systematic problem-solving methodologies to complex challeng
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 
@@ -301,7 +301,7 @@ Identify risks and mitigation:
 <template-output>risk_mitigation</template-output>
 <template-output>adjustment_triggers</template-output>
 
-<action>If the user will NOT run the optional Step 9 reflection, run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
+<action>If the user will NOT run the optional Step 9 reflection, run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
 </step>
 
 <step n="9" goal="Capture lessons learned" optional="true">
@@ -319,7 +319,7 @@ Facilitate reflection:
 <template-output>what_worked</template-output>
 <template-output>what_to_avoid</template-output>
 
-<action>Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
+<action>Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
 </step>
 
 </workflow>

--- a/src/skills/bmad-cis-storytelling/SKILL.md
+++ b/src/skills/bmad-cis-storytelling/SKILL.md
@@ -20,7 +20,7 @@ description: 'Craft compelling narratives using story frameworks. Use when the u
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 
@@ -347,7 +347,7 @@ Confirm completion with: "Story complete, {user_name}! Your narrative has been s
 
 <template-output>agent_role, agent_name, user_name, date</template-output>
 
-<action>Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
+<action>Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
 </step>
 
 </workflow>


### PR DESCRIPTION
Adds `--project-root {project-root}` to all 15 `resolve_customization.py` invocation sites across 10 skill files (6 agents, 4 workflows, including the `workflow.on_complete` terminal hooks).

## Why

`resolve_customization.py` inferred the project root when `--project-root` was absent, walking up from the **skill's installed directory**. For a skill installed under the user's home that walk reaches `~` — and a user-level install's `~/_bmad` made home look like the project. Team overrides in the real project were silently ignored: no error, no warning, just shipped defaults.

The resolver itself is fixed in bmad-code-org/BMAD-METHOD#2802. **That is what actually repairs existing installs** — this module ships no copy of the script and calls core's at `{project-root}/_bmad/scripts/`, so it inherits the fix on upgrade with nothing to do here.

This PR is the hardening half. Passing the root explicitly leaves nothing to infer, and matches `resolve_config.py`, which has always required the flag.

## Safety

No behaviour change wherever the inference already landed correctly, which is the common case. `--project-root` has always existed, so there is no version skew in either direction: new skill text works against an old resolver, and old text against the new one. This can merge before or after #2802.

Refs bmad-code-org/BMAD-METHOD#2796

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8Hyqmp2giAVgEAnB49zEQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved customization resolution across brainstorming, problem-solving, design-thinking, innovation, presentation, and storytelling workflows.
  - Ensured project-specific settings are consistently resolved using the active project context.
  - Updated activation and completion steps to provide the correct project context throughout supported workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->